### PR TITLE
simpler crafting, recycling recipes

### DIFF
--- a/kubejs/server_scripts/quickRecipes.js
+++ b/kubejs/server_scripts/quickRecipes.js
@@ -69,7 +69,7 @@ ServerEvents.recipes(event=>{
         .keepIngredient("create:wrench")
         //appending "manual_only" means this recipe can't be automated. it's strictly
         //for player convenience, and no production line should depend on it.
-        .id(`kubejs:uncraft_${Item.of(output).id}_${Item.of(input).id}_manual_only`)
+        .id(`kubejs:uncraft_${Item.of(output).id.replace(":","_")}_${Item.of(input).id.replace(":","_")}_manual_only`)
     }
   }
 

--- a/kubejs/server_scripts/quickRecipes.js
+++ b/kubejs/server_scripts/quickRecipes.js
@@ -1,0 +1,89 @@
+//this script handles making variants of recipes suited to the 2x2 inventory grid
+
+ServerEvents.recipes(event=>{
+  function replaceRecipeShaped(output,shape,key){
+    let item = Item.of(output);
+    event.remove({ output: item.id });
+    event.shaped(item,shape,key);
+  }
+  function replaceRecipeShapeless(output,ingredients){
+    let item = Item.of(output);
+    event.remove({ output: item.id });
+    event.shapeless(item,ingredients);
+  }
+
+  //kinetics parts simpification
+  event.shaped("2x create:gearbox", ["AA"], {A: "kubejs:basic_mechanism"});
+  event.shaped("2x create:vertical_gearbox", ["A", "A"], {A: "kubejs:basic_mechanism"});
+  event.shaped("2x create:chute", ["A", "B"], {A: "kubejs:basic_mechanism", B: "create:andesite_alloy"});
+  event.shaped("2x minecraft:hopper", ["B ", "AB"], {A: "kubejs:basic_mechanism", B: "create:andesite_alloy"});
+  event.shapeless("create:water_wheel", ["kubejs:basic_mechanism","2x #minecraft:logs"]);
+  event.shapeless("create:large_water_wheel", ["create:water_wheel","2x #minecraft:logs"]);
+  event.shapeless("create:clutch",["kubejs:basic_mechanism","create:shaft","#forge:dusts/redstone"]);
+  event.shapeless("create:gearshift",["kubejs:basic_mechanism","create:cogwheel","#forge:dusts/redstone"]);
+  event.shapeless("3x create:encased_chain_drive",["kubejs:basic_mechanism","3x #forge:nuggets/iron"]);
+
+  event.shapeless("create:andesite_casing",["kubejs:basic_mechanism", "#minecraft:logs"])
+  event.shapeless("create:copper_casing",["kubejs:copper_mechanism", "#minecraft:logs"])
+  event.shapeless("create:brass_casing",["create:precision_mechanism", "#minecraft:logs"])
+  event.shapeless("alloyed:steel_casing",["kubejs:steel_mechanism", "#minecraft:logs"])
+
+  // in-inventory logistics component crafting
+  replaceRecipeShaped("create:andesite_funnel", ["A", "B"], { A: "kubejs:basic_mechanism", B: "thermal:cured_rubber" });
+  replaceRecipeShaped("create:andesite_tunnel", ["AB"], { A: "kubejs:basic_mechanism", B: "thermal:cured_rubber" });
+  replaceRecipeShaped("create:belt_connector", [ "AA" ], { A: "thermal:cured_rubber" });
+  replaceRecipeShaped("create:weighted_ejector", [ "A", "B" ], { A: "kubejs:basic_mechanism", B: "create:depot" });
+  event.shaped("create:depot", ["A", "B"], {A: "create:andesite_alloy", B: "kubejs:basic_mechanism"})
+
+  replaceRecipeShaped("create:brass_funnel", ["B", "C"], { B: "create:precision_mechanism", C: "thermal:cured_rubber" });
+  replaceRecipeShaped("create:brass_tunnel", ["BC"], { B: "create:precision_mechanism", C: "thermal:cured_rubber" });
+  
+
+  // in-inventory redstone part crafting
+  event.shaped("minecraft:piston",["AL","RC"], { A: "create:andesite_alloy", L: "#minecraft:logs", R: "#forge:dusts/redstone", C: "minecraft:cobblestone" });
+  replaceRecipeShaped("minecraft:repeater",["TT","CC"], { T: "minecraft:redstone_torch", C: "minecraft:cobblestone" });
+  replaceRecipeShaped("minecraft:comparator",["TC","CT"], { T: "minecraft:redstone_torch", C: "minecraft:cobblestone" });
+  replaceRecipeShaped("create:pulse_extender",["MT","CC"], { M: "create:precision_mechanism", T: "minecraft:redstone_torch", C: "minecraft:cobblestone"});
+  replaceRecipeShaped("create:pulse_repeater",["TM","CC"], { M: "create:precision_mechanism", T: "minecraft:redstone_torch", C: "minecraft:cobblestone"});
+  replaceRecipeShaped("create:stockpile_switch",["BC"], { B: "create:precision_mechanism", C: "#forge:dusts/redstone" });
+  replaceRecipeShaped("create:content_observer",["BC"], { B: "create:precision_mechanism", C: "minecraft:observer" });
+  event.shaped("minecraft:observer",["EC","CC"], { E: "create:electron_tube", C: "minecraft:cobblestone"});
+
+  // in-inventory fluid component crafting
+  replaceRecipeShapeless("2x create:fluid_tank",["kubejs:copper_mechanism","#forge:glass"])
+  replaceRecipeShaped("create:spout", ["A", "B"], { A: "kubejs:copper_mechanism", B: "thermal:cured_rubber" });
+  replaceRecipeShaped("create:item_drain", ["B", "A"], { A: "kubejs:copper_mechanism", B: "thermal:cured_rubber" });
+  replaceRecipeShaped("create:smart_fluid_pipe", ["A", "C"], { A: "#forge:plates/gold", C: "kubejs:copper_mechanism" });
+  replaceRecipeShaped("2x create:smart_fluid_pipe", ["A", "C"], { A: "create:precision_mechanism", C: "kubejs:copper_mechanism" });
+  replaceRecipeShaped("create:fluid_valve", ["A", "C"], { A: "#forge:plates/iron", C: "kubejs:copper_mechanism" });
+  replaceRecipeShaped("create:fluid_valve", ["A", "C"], { A: "create:kinetic_mechanism", C: "kubejs:copper_mechanism" });
+  replaceRecipeShapeless("create:hose_pulley", ["kubejs:copper_mechanism", "3x thermal:cured_rubber"]);
+  event.shapeless("8x create:fluid_pipe", ["#forge:plates/copper", "kubejs:copper_mechanism"]);
+
+  // component reaquisition
+  function reconstitute(output, input){
+    if(Array.isArray(output)){
+      output.forEach(o=>reconstitute(o,input))
+    }else{
+      event.shapeless(output,[input,"create:wrench"])
+        .keepIngredient("create:wrench")
+        //appending "manual_only" means this recipe can't be automated. it's strictly
+        //for player convenience, and no production line should depend on it.
+        .id(`kubejs:uncraft_${Item.of(output).id}_${Item.of(input).id}_manual_only`)
+    }
+  }
+
+  // reconstitution recipes, for turning items back into more basic ingredients
+  reconstitute(["minecraft:redstone", "create:andesite_alloy", "create:shaft"], "create:clutch")
+  reconstitute(["minecraft:redstone", "create:andesite_alloy", "create:cogwheel"], "create:gearshift")
+  reconstitute(["1x thermal:cured_rubber", "kubejs:basic_mechanism"], "create:andesite_tunnel")
+  reconstitute(["1x thermal:cured_rubber", "kubejs:basic_mechanism"], "create:andesite_funnel")
+  reconstitute(["1x thermal:cured_rubber", "create:precision_mechanism"], "create:brass_tunnel")
+  reconstitute(["1x thermal:cured_rubber", "create:precision_mechanism"], "create:brass_funnel")
+  reconstitute("2x thermal:cured_rubber", "create:belt_connector")
+  reconstitute(["3x create:cogwheel" , "1x create:large_cogwheel", "1x create:andesite_alloy"], "kubejs:basic_mechanism");
+  reconstitute("1x create:electron_tube","create:precision_mechanism");
+  reconstitute(["2x create:copper_sheet", "4x create:fluid_pipe"], "kubejs:copper_mechanism")
+  reconstitute(["create:fluid_pipe", "create:cogwheel"], "create:mechanical_pump");
+  reconstitute("create:cogwheel", "create:large_cogwheel");
+})

--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -530,14 +530,8 @@ ServerEvents.recipes((event) => {
   event.remove({ output: "createsifter:sifter", type: "crafting_shaped" });
   event.remove({ output: "createaddition:rolling_mill", type: "crafting_shaped" });
   event.remove({ output: "thermal:slag" });
-  event.remove({ output: "create:spout" });
   event.remove({ output: "create_enchantment_industry:printer" });
   event.remove({ output: "ad_astra:iron_rod" });
-  event.remove({ output: "create:fluid_tank", type: "crafting_shaped" });
-  event.remove({ output: "create:hose_pulley", type: "crafting_shaped" });
-  event.remove({ output: "create:item_drain", type: "crafting_shaped" });
-  event.remove({ output: "create:smart_fluid_pipe", type: "crafting_shaped" });
-  event.remove({ output: "create:fluid_valve", type: "crafting_shapeless" });
   event.remove({ output: "create_enchantment_industry:disenchanter", type: "crafting_shaped" });
   event.remove({ output: "ad_astra:tier_1_rocket" });
   event.remove({ output: "ad_astra:tier_2_rocket" });
@@ -559,11 +553,6 @@ ServerEvents.recipes((event) => {
   event.remove({ output: "ad_astra:water_pump" });
   event.remove({ output: "create:steam_engine" });
   event.remove({ output: "create:extendo_grip" });
-  event.remove({ output: "create:brass_funnel" });
-  event.remove({ output: "create:brass_tunnel" });
-  event.remove({ output: "create:andesite_funnel" });
-  event.remove({ output: "create:andesite_tunnel" });
-  event.remove({ output: "create:belt_connector" });
   event.remove({ output: "prettypipes:pressurizer" });
   event.remove({ output: "prettypipes:item_terminal" });
   event.remove({ output: "prettypipes:crafting_terminal" });
@@ -869,6 +858,29 @@ ServerEvents.recipes((event) => {
       item: "kubejs:incomplete_steel_mechanism",
     },
   });
+
+
+   // alternate molten mixing recipe. commented til it gets some go-ahead
+   /* event.custom({
+    type: "create:mixing",
+    ingredients: [
+      {
+        amount: 100,
+        fluid: "kubejs:molten_brass",
+      },
+      {
+        item: "kubejs:basic_mechanism",
+      },
+      {
+        item: "create:electron_tube",
+      },
+    ],
+    results: [
+      {
+        item: "create:precision_mechanism",
+      },
+    ],
+  }); */
 
   // Precision Mechanism, Base = Basic Mechanism, 1x Deploying Brass Sheet, 1x Deploying Electron Tube, 1x Deploying Brass Nugget, 1x Pressing
   event.custom({
@@ -2438,26 +2450,10 @@ ServerEvents.recipes((event) => {
     .shaped(Item.of("4x thermal:rubber"), ["AAA", "ABA", "AAA"], { A: "#minecraft:logs_that_burn", B: "minecraft:water_bucket" })
     .replaceIngredient("minecraft:water_bucket", "minecraft:water_bucket");
 
-  // Copper Mechanism, Cured Rubber = Spout
-  event.shaped(Item.of("create:spout"), ["A", "B"], { A: "kubejs:copper_mechanism", B: "thermal:cured_rubber" });
 
   // Copper Mechanism, Cured Rubber, Plates/Iron = Printer
   event.shaped(Item.of("create_enchantment_industry:printer"), ["A", "B", "C"], { A: "kubejs:copper_mechanism", B: "thermal:cured_rubber", C: "#forge:plates/iron" });
 
-  // Plates/Copper, Copper Mechanism, Barrel = Fluid Tank
-  event.shaped(Item.of("create:fluid_tank"), ["ABA", "ACA", "ABA"], { A: "#forge:plates/copper", B: "kubejs:copper_mechanism", C: "minecraft:barrel" });
-
-  // Copper Mechanism, Dried Kelp Block, Plates/Copper = Hose Pulley
-  event.shaped(Item.of("create:hose_pulley"), ["B", "C", "A"], { A: "#forge:plates/copper", B: "kubejs:copper_mechanism", C: "minecraft:dried_kelp_block" });
-
-  // Iron Bars, Copper Mechanism = Item Drain
-  event.shaped(Item.of("create:item_drain"), ["B", "A"], { A: "kubejs:copper_mechanism", B: "minecraft:iron_bars" });
-
-  // Plates/Gold, Fluid Pipe, Copper Mechanism = Smart Fluid Pipe
-  event.shaped(Item.of("create:smart_fluid_pipe"), ["A", "B", "C"], { A: "#forge:plates/gold", B: "create:fluid_pipe", C: "kubejs:copper_mechanism" });
-
-  // Plates/Iron, Fluid Pipe, Copper Mechanism = Fluid Valve
-  event.shaped(Item.of("create:fluid_valve"), ["A", "B", "C"], { A: "#forge:plates/iron", B: "create:fluid_pipe", C: "kubejs:copper_mechanism" });
 
   // Sandpaper, Copper Casing, Copper Mechanism = Disenchanter
   event.shaped(Item.of("create_enchantment_industry:disenchanter"), ["C", "A", "B"], { A: "create:copper_casing", B: "kubejs:copper_mechanism", C: "#create:sandpaper" });
@@ -2533,20 +2529,7 @@ ServerEvents.recipes((event) => {
   // Plates/Gold, Engine, Copper Block = Steam Engine
   event.shaped(Item.of("create:steam_engine"), ["A", "B", "C"], { A: "#forge:plates/gold", B: "immersive_aircraft:engine", C: "minecraft:copper_block" });
 
-  // Electron Tube, Precision Mechanism, Cured Rubber = Brass Funnel
-  event.shaped(Item.of("create:brass_funnel"), ["A", "B", "C"], { A: "create:electron_tube", B: "create:precision_mechanism", C: "thermal:cured_rubber" });
-
-  // Electron Tube, Precision Mechanism, Cured Rubber = Brass Tunnel
-  event.shaped(Item.of("create:brass_tunnel"), ["AA", "BB", "CC"], { A: "create:electron_tube", B: "create:precision_mechanism", C: "thermal:cured_rubber" });
-
-  // Basic Mechanism, Cured Rubber = Andesite Funnel
-  event.shaped(Item.of("create:andesite_funnel"), ["A", "B"], { A: "kubejs:basic_mechanism", B: "thermal:cured_rubber" });
-
-  // Basic Mechanism, Cured Rubber = Andesite Tunnel
-  event.shaped(Item.of("create:andesite_tunnel"), ["AA", "BB"], { A: "kubejs:basic_mechanism", B: "thermal:cured_rubber" });
-
-  // Cured Rubber = Mechanical Belt
-  event.shaped(Item.of("create:belt_connector"), ["AAA"], { A: "thermal:cured_rubber" });
+  
 
   // Precision Mechanism, High Speed Module, Redstone Block = Pipe Pressurizer
   event.shaped(Item.of("prettypipes:pressurizer"), ["ABA", "DCD", "ABA"], {


### PR DESCRIPTION
recycling recipes allow for some probably-balanced uncrafting. the simplification's main goal is causing a majority of basic components to not need you to use a crafting table once you have access to mechanisms, saving precious time. 2x2 grid for life